### PR TITLE
Extend EnOsc pitch and root cv ranges to -8V to +8V

### DIFF
--- a/4ms/core/EnOscCore.cc
+++ b/4ms/core/EnOscCore.cc
@@ -131,44 +131,57 @@ public:
 		}
 	}
 
-	void set_input(int input_id, float val) override {
+	void set_input(int input_id, float cv) override {
 		using AdcInput = EnOsc::AdcInput;
 		using SpiAdcInput = EnOsc::SpiAdcInput;
 
-		val /= 5.f;	  //-5V to +5V => -1..1
-		val *= -0.5f; //-1..1 => 0.5..-0.5
-		val += 0.5f;  // => 1..0
-					  // Ui::set_potcv will clamp
+		auto cv_to_val = [](float cv) {
+			float val = cv / 5.f; // -5V to +5V => -1..1
+			val *= -0.5f;	// -1..1 => 0.5..-0.5
+			val += 0.5f;	// => 1..0
+			return val;
+		};
+
+		auto pitchcv_to_val = [](float cv) {
+			float val = cv / 8.f; // -8V to +8V => -1..1
+			val *= -0.5f;	// -1..1 => 0.5..-0.5
+			val += 0.5f;	// => 1..0
+			return val;
+		};
+
+		constexpr float gate_threshold = 1.5f;
+
+		// Ui::set_potcv will clamp
 		switch (input_id) {
 			case Info::InputBalance_Jack:
-				enosc.set_potcv(AdcInput::CV_BALANCE, val);
+				enosc.set_potcv(AdcInput::CV_BALANCE, cv_to_val(cv));
 				break;
 			case Info::InputCross_Fm_Jack:
-				enosc.set_potcv(AdcInput::CV_MOD, val);
+				enosc.set_potcv(AdcInput::CV_MOD, cv_to_val(cv));
 				break;
 			case Info::InputPitch_Jack:
-				enosc.set_pitchroot_cv(SpiAdcInput::CV_PITCH, val);
+				enosc.set_pitchroot_cv(SpiAdcInput::CV_PITCH, pitchcv_to_val(cv));
 				break;
 			case Info::InputRoot_Jack:
-				enosc.set_pitchroot_cv(SpiAdcInput::CV_ROOT, val);
+				enosc.set_pitchroot_cv(SpiAdcInput::CV_ROOT, pitchcv_to_val(cv));
 				break;
 			case Info::InputScale_Jack:
-				enosc.set_potcv(AdcInput::CV_SCALE, val);
+				enosc.set_potcv(AdcInput::CV_SCALE, cv_to_val(cv));
 				break;
 			case Info::InputSpread_Jack:
-				enosc.set_potcv(AdcInput::CV_SPREAD, val);
+				enosc.set_potcv(AdcInput::CV_SPREAD, cv_to_val(cv));
 				break;
 			case Info::InputTwist_Jack:
-				enosc.set_potcv(AdcInput::CV_TWIST, val);
+				enosc.set_potcv(AdcInput::CV_TWIST, cv_to_val(cv));
 				break;
 			case Info::InputWarp_Jack:
-				enosc.set_potcv(AdcInput::CV_WARP, val);
+				enosc.set_potcv(AdcInput::CV_WARP, cv_to_val(cv));
 				break;
 			case Info::InputFreeze_Jack:
-				enosc.set_freeze_gate(val > 0.5f);
+				enosc.set_freeze_gate(cv > gate_threshold);
 				break;
 			case Info::InputLearn_Jack:
-				enosc.set_learn_gate(val > 0.5f);
+				enosc.set_learn_gate(cv > gate_threshold);
 				break;
 		}
 	}

--- a/4ms/core/enosc/control.hh
+++ b/4ms/core/enosc/control.hh
@@ -289,10 +289,11 @@ class Control : public EventSource<Event> {
 	};
 	CalibrationData calibration_data_;
 	CalibrationData default_calibration_data_ = {
-		.pitch_offset = 0.5_f,
-		.pitch_slope = -120._f,
+		// EnOscCore::set_input: -8V .. +8V => +1 .. 0
+		.pitch_offset = 0.5_f,	//          => +0.5 .. -0.5
+		.pitch_slope = -192._f, //          => -96 .. +96 (semitones) = -8oct .. +8oct
 		.root_offset = 0.5_f,
-		.root_slope = -120._f,
+		.root_slope = -192._f,
 		.warp_offset = 0._f,
 		.balance_offset = 0._f,
 		.twist_offset = 0._f,


### PR DESCRIPTION
Extends the EnOsc pitch CV and root CV ranges. Hardware is limited to -2V to +6V, but we chose not to replicate this.