### PR TITLE
Consistent use of getInput<> regarding patched status of a cable

### DIFF
--- a/4ms/core/ENVVCACore.cc
+++ b/4ms/core/ENVVCACore.cc
@@ -112,10 +112,9 @@ public:
 			osc.setTargetVoltage(followInput.process(*inputFollowValue));
 		}
 
-		if (auto triggerInputValue = getInput<TriggerIn>(); triggerInputValue) {
-			if (triggerEdgeDetector(triggerDetector(*triggerInputValue))) {
-				osc.doRetrigger();
-			}
+		auto triggerInputValue = getInput<TriggerIn>().value_or(0.f);
+		if (triggerEdgeDetector(triggerDetector(triggerInputValue))) {
+			osc.doRetrigger();
 		}
 
 		osc.proceed(timeStepInS);
@@ -145,14 +144,13 @@ public:
 			return InvertingAmpWithBias(offset, 100e3f, 100e3f, bias);
 		};
 
-		if (auto timeCVValue = getInput<TimeCvIn>(); timeCVValue) {
-			// scale down cv input
-			const auto scaledTimeCV = *timeCVValue * -100e3f / 137e3f;
+		auto timeCVValue = getInput<TimeCvIn>().value_or(0.f);
+		// scale down cv input
+		const auto scaledTimeCV = timeCVValue * -100e3f / 137e3f;
 
-			// apply attenuverter knobs
-			rScaleLEDs = InvertingAmpWithBias(scaledTimeCV, 100e3f, 100e3f, getState<RiseCvKnob>() * scaledTimeCV);
-			fScaleLEDs = InvertingAmpWithBias(scaledTimeCV, 100e3f, 100e3f, getState<FallCvKnob>() * scaledTimeCV);
-		}
+		// apply attenuverter knobs
+		rScaleLEDs = InvertingAmpWithBias(scaledTimeCV, 100e3f, 100e3f, getState<RiseCvKnob>() * scaledTimeCV);
+		fScaleLEDs = InvertingAmpWithBias(scaledTimeCV, 100e3f, 100e3f, getState<FallCvKnob>() * scaledTimeCV);
 
 		// sum with static value from fader + range switch
 		auto riseRange = getState<RiseSwitch>();

--- a/4ms/core/L4Core.cc
+++ b/4ms/core/L4Core.cc
@@ -27,71 +27,71 @@ public:
 		float outputLeft = 0.f;
 		float outputRight = 0.f;
 
-		auto channelLeft = 0.f;
-		auto channelRight = channelLeft;
-
-		if(auto input = getInput<In1In>(); input) {
-			auto filteredInput = channel1DCBlocker(*input);
-			channelLeft = filteredInput * PanningTable.lookup(1.f - getState<Pan1Knob>()) * LevelTable.lookup(getState<Level1Knob>());
-			channelRight = filteredInput * PanningTable.lookup(getState<Pan1Knob>()) * LevelTable.lookup(getState<Level1Knob>());
+		{
+			auto input = getInput<In1In>().value_or(0.f);
+			auto filteredInput = channel1DCBlocker(input);
+			auto channelLeft = filteredInput * PanningTable.lookup(1.f - getState<Pan1Knob>()) * LevelTable.lookup(getState<Level1Knob>());
+			auto channelRight = filteredInput * PanningTable.lookup(getState<Pan1Knob>()) * LevelTable.lookup(getState<Level1Knob>());
 
 			outputLeft += channelLeft;
 			outputRight += channelRight;
+
+			setLED<Level1LedLight>(std::array<float,3>{0.f, channel1EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel1EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
 		}
 
-		setLED<Level1LedLight>(std::array<float,3>{0.f, channel1EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel1EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
-
-		channelLeft = 0.f;
-		channelRight = channelLeft;
-
-		if(auto input = getInput<In2In>(); input) {
+		{
+			auto input = getInput<In2In>();
 			auto filteredInput = channel2DCBlocker(*input);
-			channelLeft = filteredInput * PanningTable.lookup(1.f - getState<Pan2Knob>()) * LevelTable.lookup(getState<Level2Knob>());
-			channelRight = filteredInput * PanningTable.lookup(getState<Pan2Knob>()) * LevelTable.lookup(getState<Level2Knob>());
+			auto channelLeft = filteredInput * PanningTable.lookup(1.f - getState<Pan2Knob>()) * LevelTable.lookup(getState<Level2Knob>());
+			auto channelRight = filteredInput * PanningTable.lookup(getState<Pan2Knob>()) * LevelTable.lookup(getState<Level2Knob>());
 
 			outputLeft += channelLeft;
 			outputRight += channelRight;
+
+			setLED<Level2LedLight>(std::array<float,3>{0.f, channel2EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel2EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
 		}
 
-		setLED<Level2LedLight>(std::array<float,3>{0.f, channel2EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel2EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
+		{
+			float channelLeft = 0.f;
+			float channelRight = 0.f;
 
-		channelLeft = 0.f;
-		channelRight = channelLeft;
-
-		if(auto inputL = getInput<In3LIn>(); inputL) {
-			auto filteredInput = channel3LeftDCBlocker(*inputL);
+			auto inputL = getInput<In3LIn>().value_or(0.f);
+			auto filteredInput = channel3LeftDCBlocker(inputL);
 			channelLeft = filteredInput * LevelTable.lookup(getState<Level3Knob>());
-			channelRight =  channelLeft;
+
+			if(auto inputR = getInput<In3RIn>(); inputR) {
+				auto filteredInput = channel3RightDCBlocker(*inputR);
+				channelRight = filteredInput * LevelTable.lookup(getState<Level3Knob>());
+
+			} else
+				channelRight =  channelLeft;
+
+			outputLeft += channelLeft;
+			outputRight += channelRight;
+
+			setLED<Level3LedLight>(std::array<float,3>{0.f, channel3EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel3EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
 		}
 
-		if(auto inputR = getInput<In3RIn>(); inputR) {
-			auto filteredInput = channel3RightDCBlocker(*inputR);
-			channelRight = filteredInput * LevelTable.lookup(getState<Level3Knob>());
-		}
+		{
+			float channelLeft = 0.f;
+			float channelRight = 0.f;
 
-		outputLeft += channelLeft;
-		outputRight += channelRight;
-
-		setLED<Level3LedLight>(std::array<float,3>{0.f, channel3EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel3EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
-
-		channelLeft = 0.f;
-		channelRight = channelLeft;
-
-		if(auto inputL = getInput<In4LIn>(); inputL) {
-			auto filteredInput = channel4LeftDCBlocker(*inputL);
+			auto inputL = getInput<In4LIn>().value_or(0.f);
+			auto filteredInput = channel4LeftDCBlocker(inputL);
 			channelLeft = filteredInput * LevelTable.lookup(getState<Level4Knob>());
-			channelRight = channelLeft;
+
+			if(auto inputR = getInput<In4RIn>(); inputR) {
+				auto filteredInput = channel4RightDCBlocker(*inputR);
+				channelRight = filteredInput * LevelTable.lookup(getState<Level4Knob>());
+
+			} else 
+				channelRight = channelLeft;
+
+			outputLeft += channelLeft;
+			outputRight += channelRight;
+
+			setLED<Level4LedLight>(std::array<float,3>{0.f, channel4EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel4EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
 		}
-
-		if(auto inputR = getInput<In4RIn>(); inputR) {
-			auto filteredInput = channel4RightDCBlocker(*inputR);
-			channelRight = filteredInput * LevelTable.lookup(getState<Level4Knob>());
-		}
-
-		outputLeft += channelLeft;
-		outputRight += channelRight;
-
-		setLED<Level4LedLight>(std::array<float,3>{0.f, channel4EnvelopeRight(gcem::abs(channelRight)) / LEDScaling , channel4EnvelopeLeft(gcem::abs(channelLeft)) / LEDScaling});
 
 		//+6dB output boost
 		outputLeft *= 2.f;

--- a/4ms/core/RCDCore.cc
+++ b/4ms/core/RCDCore.cc
@@ -22,21 +22,19 @@ public:
 		readSwitches();
 		readRotate();
 
-		if (auto resetInputValue = getInput<ResetIn>(); resetInputValue) {
-			if (resetTriggerEdgeDetector(resetTriggerDetector(*resetInputValue))) {
-				reset();
-			}
+		auto resetInputValue = getInput<ResetIn>().value_or(0);
+		if (resetTriggerEdgeDetector(resetTriggerDetector(resetInputValue))) {
+			reset();
 		}
 
 		recalculateDivisions();
 
-		if (auto clockInputValue = getInput<ClkIn>(); clockInputValue) {
-			const auto clockTrigger = clockTriggerDetector(*clockInputValue);
-			if (clockTriggerRisingEdgeDetector(clockTrigger)) {
-				processRisingClockEdge();
-			} else if (clockTriggerFallingEdgeDetector(clockTrigger)) {
-				processFallingClockEdge();
-			}
+		const auto clockInputValue = getInput<ClkIn>().value_or(0);
+		const auto clockTrigger = clockTriggerDetector(clockInputValue);
+		if (clockTriggerRisingEdgeDetector(clockTrigger)) {
+			processRisingClockEdge();
+		} else if (clockTriggerFallingEdgeDetector(clockTrigger)) {
+			processFallingClockEdge();
 		}
 	}
 
@@ -124,18 +122,15 @@ private:
 	}
 
 	void readRotate() {
-		if(auto rotateValue = getInput<RotateIn>(); rotateValue) {
-			adc = uint32_t(std::clamp(*rotateValue, 0.f, 5.f) / 5.f * 255.f);
-		} else {
-			adc = 0;
-		}
+		auto rotateValue = getInput<RotateIn>().value_or(0);
+		adc = uint32_t(std::clamp(rotateValue, 0.f, 5.f) / 5.f * 255.f);
 	}
 
-	void reset(void) {
+	void reset() {
 		counters.fill(0);
 	}
 
-	void recalculateDivisions(void) {
+	void recalculateDivisions() {
 		uint32_t rotationAmount = 0;
 
 		if (spreadMode == Spread_t::SPREAD_ON){

--- a/4ms/core/SCMCore.cc
+++ b/4ms/core/SCMCore.cc
@@ -263,7 +263,7 @@ public:
 
 private:
 	// Controls/Outs
-	std::array<bool, Info::NumOutJacks> outs;
+	std::array<bool, Info::NumOutJacks> outs{};
 
 	static constexpr bool DoFreeRun = true; //TODO: make this a switch?
 
@@ -280,17 +280,17 @@ private:
 	uint8_t slip_howmany = 0;
 
 	// Params (states)
-	bool clkin;
-	bool mute;
-	bool is_running;
-	bool resync;
+	bool clkin{};
+	bool mute{};
+	bool is_running{};
+	bool resync{};
 
 	// Flags
-	bool update_pulse_params;
-	bool update_slip_params;
+	bool update_pulse_params{};
+	bool update_slip_params{};
 
 	// Multiply-by for each jack
-	std::array<uint32_t, 8> d;
+	std::array<uint32_t, 8> d{};
 
 	// Phase counters
 	uint32_t tmr_int = 0;
@@ -298,20 +298,20 @@ private:
 
 	std::array<uint32_t, 8> tmr{};
 	uint32_t period = 84000;
-	std::array<uint32_t, 8> per;
+	std::array<uint32_t, 8> per{};
 
 	// Pulse-width
 	std::array<uint32_t, 8> pw{8400, 4200, 2800, 2200, 1680, 1400, 1050, 1050};
 	static constexpr uint32_t MIN_PW = 50;
 
 	// Beat counters for Skip feature
-	std::array<uint32_t, 8> p;
+	std::array<uint32_t, 8> p{};
 
 	// Counters for slip
-	std::array<uint32_t, 8> s;
-	std::array<uint32_t, 8> dd;
-	std::array<int32_t, 8> slipamt;
-	std::array<int32_t, 8> slip;
+	std::array<uint32_t, 8> s{};
+	std::array<uint32_t, 8> dd{};
+	std::array<int32_t, 8> slipamt{};
+	std::array<int32_t, 8> slip{};
 };
 
 } // namespace MetaModule

--- a/4ms/core/TapoCore.cc
+++ b/4ms/core/TapoCore.cc
@@ -252,10 +252,10 @@ private:
 		{
 			return std::clamp(voltage / (2 * BiploarCVInputFullScaleInVolt) + 0.5f, 0.0f, 1.0f);
 		};
-		if (auto val=getInput<TimeJackIn>(); val)       adc.set(ADC_SCALE_CV,      BipolarCVInputFunc(*val));
-		if (auto val=getInput<FeedbackJackIn>(); val)   adc.set(ADC_FEEDBACK_CV,   BipolarCVInputFunc(*val));
-		if (auto val=getInput<ModulationJackIn>(); val) adc.set(ADC_MODULATION_CV, BipolarCVInputFunc(*val));
-		if (auto val=getInput<DryWetJackIn>(); val)     adc.set(ADC_DRYWET_CV,     BipolarCVInputFunc(*val));
+		{auto val=getInput<TimeJackIn>().value_or(0);       adc.set(ADC_SCALE_CV,      BipolarCVInputFunc(val));}
+		{auto val=getInput<FeedbackJackIn>().value_or(0);   adc.set(ADC_FEEDBACK_CV,   BipolarCVInputFunc(val));}
+		{auto val=getInput<ModulationJackIn>().value_or(0); adc.set(ADC_MODULATION_CV, BipolarCVInputFunc(val));}
+		{auto val=getInput<DryWetJackIn>().value_or(0);     adc.set(ADC_DRYWET_CV,     BipolarCVInputFunc(val));}
 
 		//
 		// Velocity CV
@@ -264,14 +264,14 @@ private:
 		{
 			return std::clamp(voltage / VelocityCVInputFullScaleInVolt, 0.0f, 1.0f);
 		};
-		if (auto val=getInput<VelocityIn>(); val)       adc.set(ADC_VEL_CV, VelocityCVInputFunc(*val));
+		{auto val=getInput<VelocityIn>().value_or(0.f);    adc.set(ADC_VEL_CV, VelocityCVInputFunc(val));}
 
 		//
 		// Gate and trigger inputs
 		//
-		if (auto val=getInput<RepeatJackIn>(); val)  gate.set(GATE_INPUT_REPEAT, *val > GateInputThresholdInVolt);
-		if (auto val=getInput<TapIn>(); val)         adc.set(ADC_TAPTRIG_CV,     *val > GateInputThresholdInVolt);		
-		if (auto val=getInput<ExtClockIn>(); val)    adc.set(ADC_CLOCK_CV,       *val > GateInputThresholdInVolt);		
+		{auto val=getInput<RepeatJackIn>().value_or(0.f);  gate.set(GATE_INPUT_REPEAT, val > GateInputThresholdInVolt);}
+		{auto val=getInput<TapIn>().value_or(0.f);         adc.set(ADC_TAPTRIG_CV,     val > GateInputThresholdInVolt);}
+		{auto val=getInput<ExtClockIn>().value_or(0.f);    adc.set(ADC_CLOCK_CV,       val > GateInputThresholdInVolt);}
 
 		//
 		// Tap Button

--- a/4ms/core/VCAMCore.cc
+++ b/4ms/core/VCAMCore.cc
@@ -35,89 +35,25 @@ public:
 		channelD3.pot(getState<D3LevelKnob>());
 		channelD4.pot(getState<D4LevelKnob>());
 
-		if (auto control = getInput<A1JackIn>(); control) {
-			channelA1.control(*control);
-		} else {
-			channelA1.control(5.f);
-		}
-		if (auto control = getInput<A2JackIn>(); control) {
-			channelA2.control(*control);
-		} else {
-			channelA2.control(5.f);
-		}
-		if (auto control = getInput<A3JackIn>(); control) {
-			channelA3.control(*control);
-		} else {
-			channelA3.control(5.f);
-		}
-		if (auto control = getInput<A4JackIn>(); control) {
-			channelA4.control(*control);
-		} else {
-			channelA4.control(5.f);
-		}
+		channelA1.control(getInput<A1JackIn>().value_or(5.f));
+		channelA2.control(getInput<A2JackIn>().value_or(5.f));
+		channelA3.control(getInput<A3JackIn>().value_or(5.f));
+		channelA4.control(getInput<A4JackIn>().value_or(5.f));
 
-		if (auto control = getInput<B1JackIn>(); control) {
-			channelB1.control(*control);
-		} else {
-			channelB1.control(5.f);
-		}
-		if (auto control = getInput<B2JackIn>(); control) {
-			channelB2.control(*control);
-		} else {
-			channelB2.control(5.f);
-		}
-		if (auto control = getInput<B3JackIn>(); control) {
-			channelB3.control(*control);
-		} else {
-			channelB3.control(5.f);
-		}
-		if (auto control = getInput<B4JackIn>(); control) {
-			channelB4.control(*control);
-		} else {
-			channelB4.control(5.f);
-		}
+		channelB1.control(getInput<B1JackIn>().value_or(5.f));
+		channelB2.control(getInput<B2JackIn>().value_or(5.f));
+		channelB3.control(getInput<B3JackIn>().value_or(5.f));
+		channelB4.control(getInput<B4JackIn>().value_or(5.f));
 
-		if (auto control = getInput<C1JackIn>(); control) {
-			channelC1.control(*control);
-		} else {
-			channelC1.control(5.f);
-		}
-		if (auto control = getInput<C2JackIn>(); control) {
-			channelC2.control(*control);
-		} else {
-			channelC2.control(5.f);
-		}
-		if (auto control = getInput<C3JackIn>(); control) {
-			channelC3.control(*control);
-		} else {
-			channelC3.control(5.f);
-		}
-		if (auto control = getInput<C4JackIn>(); control) {
-			channelC4.control(*control);
-		} else {
-			channelC4.control(5.f);
-		}
+		channelC1.control(getInput<C1JackIn>().value_or(5.f));
+		channelC2.control(getInput<C2JackIn>().value_or(5.f));
+		channelC3.control(getInput<C3JackIn>().value_or(5.f));
+		channelC4.control(getInput<C4JackIn>().value_or(5.f));
 
-		if (auto control = getInput<D1JackIn>(); control) {
-			channelD1.control(*control);
-		} else {
-			channelD1.control(5.f);
-		}
-		if (auto control = getInput<D2JackIn>(); control) {
-			channelD2.control(*control);
-		} else {
-			channelD2.control(5.f);
-		}
-		if (auto control = getInput<D3JackIn>(); control) {
-			channelD3.control(*control);
-		} else {
-			channelD3.control(5.f);
-		}
-		if (auto control = getInput<D4JackIn>(); control) {
-			channelD4.control(*control);
-		} else {
-			channelD4.control(5.f);
-		}
+		channelD1.control(getInput<D1JackIn>().value_or(5.f));
+		channelD2.control(getInput<D2JackIn>().value_or(5.f));
+		channelD3.control(getInput<D3JackIn>().value_or(5.f));
+		channelD4.control(getInput<D4JackIn>().value_or(5.f));
 
 		channelA1.mute(getState<A1Button>() == LatchingButton::State_t::UP);
 		channelA2.mute(getState<A2Button>() == LatchingButton::State_t::UP);

--- a/4ms/core/vcam/vcam_channel.h
+++ b/4ms/core/vcam/vcam_channel.h
@@ -2,48 +2,44 @@
 
 #include "Tables.h"
 
-class Channel
-{
+class Channel {
 public:
-    Channel()
-        : potValue(0.f), inputValue(0.f), outputValue(0.f), controlValue(0.f), muteValue(0.f) {
+	Channel() = default;
 
-    }
+	void input(float input) {
+		inputValue = input;
+	}
 
-    void input(float input) {
-        inputValue = input;
-    }
+	void pot(float pot) {
+		potValue = pot;
+	}
 
-    void pot(float pot) {
-        potValue = pot;
-    }
+	void control(float control) {
+		controlValue = control;
+	}
 
-    void control(float control) {
-        controlValue = control;
-    }
+	void mute(bool isMuted) {
+		if (isMuted == true) {
+			muteValue = 0.f;
+		} else {
+			muteValue = 1.f;
+		}
+	}
 
-    void mute(bool isMuted) {
-        if (isMuted == true) {
-            muteValue = 0.f;
-        } else {
-            muteValue = 1.f;
-        }
-    }
+	float output() {
+		outputValue = inputValue * VoltageToGainTable.lookup(potValue * controlValue * muteValue);
 
-    float output(void) {
-        outputValue = inputValue * VoltageToGainTable.lookup(potValue * controlValue * muteValue);
+		return outputValue;
+	}
 
-        return outputValue;
-    }
-
-    float getLEDbrightness(void) {
-        return VoltageToGainTable.lookup(potValue * controlValue * muteValue);
-    }
+	float getLEDbrightness() {
+		return VoltageToGainTable.lookup(potValue * controlValue * muteValue);
+	}
 
 private:
-float potValue;
-float inputValue;
-float outputValue;
-float controlValue;
-float muteValue;
+	float potValue{};
+	float inputValue{};
+	float outputValue{};
+	float controlValue{};
+	float muteValue{};
 };


### PR DESCRIPTION
Fixes using `getInput` on a patched cable that's not sending signal

E.g. a MIDI connection to a jack marks the jack as patched, but the engine only calls CoreProcessor::set_input() when there's a MIDI event.

Now, when `getInput` returns `nullopt`, it means the cable is not patched
