### PR TITLE
Add bypass routes to effect modules

### DIFF
--- a/4ms/info/BPF_info.hh
+++ b/4ms/info/BPF_info.hh
@@ -53,11 +53,11 @@ struct BPFInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputBandpass_Out, 
+        OutputBandpass_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputBandpass_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/DLD_info.hh
+++ b/4ms/info/DLD_info.hh
@@ -194,8 +194,10 @@ struct DLDInfo : ModuleInfoBase {
         NumDiscreteLeds,
     };
     
+    static constexpr std::array<BypassRoute, 2> bypass_routes{{{InputIn_A, OutputOut_A}, {InputIn_B, OutputOut_B}}};
+
     enum {
-        AltParamSoft_Clip_A, 
+        AltParamSoft_Clip_A,
         AltParamSoft_Clip_B, 
         AltParamAutomute_A, 
         AltParamAutomute_B, 

--- a/4ms/info/Detune_info.hh
+++ b/4ms/info/Detune_info.hh
@@ -56,11 +56,11 @@ struct DetuneInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputAudio_Out, 
+        OutputAudio_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputAudio_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/Freeverb_info.hh
+++ b/4ms/info/Freeverb_info.hh
@@ -62,11 +62,11 @@ struct FreeverbInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputOut, 
+        OutputOut,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputInput, OutputOut}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/HPF_info.hh
+++ b/4ms/info/HPF_info.hh
@@ -53,11 +53,11 @@ struct HPFInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputAudio_Out, 
+        OutputAudio_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputAudio_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/LPG_info.hh
+++ b/4ms/info/LPG_info.hh
@@ -59,11 +59,11 @@ struct LPGInfo : ModuleInfoBase {
     };
     
     enum {
-        AudioOutOutput, 
+        AudioOutOutput,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{AudioInInput, AudioOutOutput}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/Pan_info.hh
+++ b/4ms/info/Pan_info.hh
@@ -46,12 +46,12 @@ struct PanInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputCh__1_Out, 
-        OutputCh__2_Out, 
+        OutputCh__1_Out,
+        OutputCh__2_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 2> bypass_routes{{{InputAudio_In, OutputCh__1_Out}, {InputAudio_In, OutputCh__2_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/PitchShift_info.hh
+++ b/4ms/info/PitchShift_info.hh
@@ -59,11 +59,11 @@ struct PitchShiftInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputAudio_Out, 
+        OutputAudio_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputAudio_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/Slew_info.hh
+++ b/4ms/info/Slew_info.hh
@@ -44,11 +44,11 @@ struct SlewInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputSlewed_Out, 
+        OutputSlewed_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputSignal_In, OutputSlewed_Out}}};
 
 };
 } // namespace MetaModule

--- a/4ms/info/Tapo_info.hh
+++ b/4ms/info/Tapo_info.hh
@@ -141,8 +141,10 @@ struct TapoInfo : ModuleInfoBase {
         NumDiscreteLeds,
     };
     
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputAudio_Out_1}}};
+
     enum {
-        AltParamVelocity, 
+        AltParamVelocity,
         AltParamBank, 
         AltParamPan, 
         AltParamMode, 

--- a/4ms/info/Verb_info.hh
+++ b/4ms/info/Verb_info.hh
@@ -74,11 +74,11 @@ struct VerbInfo : ModuleInfoBase {
     };
     
     enum {
-        OutputAudio_Out, 
+        OutputAudio_Out,
         NumOutJacks,
     };
-    
-    
+
+    static constexpr std::array<BypassRoute, 1> bypass_routes{{{InputAudio_In, OutputAudio_Out}}};
 
 };
 } // namespace MetaModule


### PR DESCRIPTION
Hey Dan, to go alongside the bypass feature on the MetaModule, this makes the 4ms effects handle bypass properly in VCV.

- Adds `bypass_routes` to Info structs for 11 effect modules (BPF, Detune, DLD, Freeverb, HPF, LPG, Pan, PitchShift, Slew, Tapo, Verb)
- Routes pass audio input straight to output when a module is bypassed
- DLD and Pan have two routes; all others have one