### PR TITLE
Fix QCD div/mult knob range: missing upper and lower extremes

### DIFF
--- a/4ms/core/QCDCore.cc
+++ b/4ms/core/QCDCore.cc
@@ -350,10 +350,11 @@ private:
 	static constexpr float triggerLengthMinimumInS = 0.005f;
 
 	static constexpr uint32_t maxIndexDivisions = 9;
-	static constexpr std::array<factorType_t, 21> clockFactor = {
-		{{DIV, 32, 0},	{DIV, 32, 1},  {DIV, 16, 2},  {DIV, 8, 3},	 {DIV, 7, 4},	 {DIV, 6, 5},	 {DIV, 5, 6},
-		 {DIV, 4, 7},	{DIV, 3, 8},   {DIV, 2, 9},	  {MULT, 1, 10}, {MULT, 2, 11},	 {MULT, 3, 12},	 {MULT, 4, 13},
-		 {MULT, 5, 14}, {MULT, 6, 15}, {MULT, 7, 16}, {MULT, 8, 17}, {MULT, 12, 18}, {MULT, 16, 19}, {MULT, 16, 20}}};
+	static constexpr std::array<factorType_t, 19> clockFactor = {{
+		{DIV, 32, 0},  {DIV, 16, 1},  {DIV, 8, 2},	 {DIV, 7, 3},	 {DIV, 6, 4},	 {DIV, 5, 5},	{DIV, 4, 6},
+		{DIV, 3, 7},   {DIV, 2, 8},	  {MULT, 1, 9},	 {MULT, 2, 10},	 {MULT, 3, 11},	 {MULT, 4, 12}, {MULT, 5, 13},
+		{MULT, 6, 14}, {MULT, 7, 16}, {MULT, 8, 16}, {MULT, 12, 17}, {MULT, 16, 18},
+	}};
 
 private:
 	float timeStepInS;

--- a/4ms/core/QCDCore.cc
+++ b/4ms/core/QCDCore.cc
@@ -350,10 +350,10 @@ private:
 	static constexpr float triggerLengthMinimumInS = 0.005f;
 
 	static constexpr uint32_t maxIndexDivisions = 9;
-	static constexpr std::array<factorType_t, 19> clockFactor = {{
+	static constexpr std::array<factorType_t, 19> clockFactor{{
 		{DIV, 32, 0},  {DIV, 16, 1},  {DIV, 8, 2},	 {DIV, 7, 3},	 {DIV, 6, 4},	 {DIV, 5, 5},	{DIV, 4, 6},
 		{DIV, 3, 7},   {DIV, 2, 8},	  {MULT, 1, 9},	 {MULT, 2, 10},	 {MULT, 3, 11},	 {MULT, 4, 12}, {MULT, 5, 13},
-		{MULT, 6, 14}, {MULT, 7, 16}, {MULT, 8, 16}, {MULT, 12, 17}, {MULT, 16, 18},
+		{MULT, 6, 14}, {MULT, 7, 15}, {MULT, 8, 16}, {MULT, 12, 17}, {MULT, 16, 18},
 	}};
 
 private:


### PR DESCRIPTION
Fixes https://github.com/4ms/4ms-vcv/issues/56